### PR TITLE
Expose Endpoint, Tokens and Log APIs

### DIFF
--- a/Sources/Entity/Endpoint.swift
+++ b/Sources/Entity/Endpoint.swift
@@ -47,16 +47,16 @@ public struct Endpoint{
         }
     }
 
-    var baseURL: String = ""
-    var path: String
-    var httpMethod: HTTPMethod
-    var contentType: ContentType?
-    var body: Data?
-    var parameters: [String: Any] = [:]
-    var query: [String: Any] = [:]
-    var headers: [String: String]
+    public var baseURL: String = ""
+    public var path: String
+    public var httpMethod: HTTPMethod
+    public var contentType: ContentType?
+    public var body: Data?
+    public var parameters: [String: Any] = [:]
+    public var query: [String: Any] = [:]
+    public var headers: [String: String]
 
-    var request: URLRequest {
+    public var request: URLRequest {
         guard var url = URL(string: baseURL + path) else { fatalError("Not a valid URL") }
         url = url.appending(parameters: query)
         var request = URLRequest(url: url)

--- a/Sources/Entity/Tokens.swift
+++ b/Sources/Entity/Tokens.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public struct Tokens {
-    var accessToken: Token
-    var refreshToken: Token
+    public var accessToken: Token
+    public var refreshToken: Token
 
     public init(accessToken: Token, refreshToken: Token) {
         self.accessToken = accessToken

--- a/Sources/Logger/Log.swift
+++ b/Sources/Logger/Log.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum LogType {
+public enum LogType {
     case error
     case info
     case warning
@@ -16,7 +16,7 @@ public enum LogFormat {
     case none
 }
 
-struct Log {
+public struct Log {
     static func time() -> String {
         let date = Date()
         let formatter = DateFormatter()
@@ -24,7 +24,7 @@ struct Log {
         return formatter.string(from: date)
     }
     
-    static func this(_ message: String, file: String = #file, function: String = #function, line: Int = #line, type: LogType = .debug) {
+    public static func this(_ message: String, file: String = #file, function: String = #function, line: Int = #line, type: LogType = .debug) {
         let path = file.split(separator: "/")
         let file = path.last?.split(separator: ".")
         
@@ -40,7 +40,7 @@ struct Log {
         print("\(self.time()) \(icon) \(file?.first ?? "").\(function):\(line) - \n\n\t\(message)\n")
     }
     
-    static func thisCall(_ call: URLRequest, format: LogFormat = .full) {
+    public static func thisCall(_ call: URLRequest, format: LogFormat = .full) {
         let url     = call.url?.absoluteString ?? ""
         let headers = call.allHTTPHeaderFields ?? [:]
         let method  = call.httpMethod ?? ""
@@ -60,7 +60,7 @@ struct Log {
         }
     }
     
-    static func thisResponse(_ response: HTTPURLResponse, data: Data, format: LogFormat = .full) {
+    public static func thisResponse(_ response: HTTPURLResponse, data: Data, format: LogFormat = .full) {
         let code = response.statusCode
         let url  = response.url?.absoluteString ?? ""
         let icon  = (200..<300).contains(code) ? "✅" : "❌"
@@ -85,7 +85,7 @@ struct Log {
         }
     }
 
-    static func thisURL(_ url: URL, format: LogFormat = .full) {
+    public static func thisURL(_ url: URL, format: LogFormat = .full) {
         let url = url.absoluteString
 
         switch format {
@@ -94,19 +94,19 @@ struct Log {
         }
     }
     
-    static func thisError(_ error : Error) {
+    public static func thisError(_ error : Error) {
         print("🤬 ERROR: \(error.localizedDescription)")
         print("🤖 RAW VALUE: \(error)")
         print("------------------------------------------")
     }
     
-    static func thisError(_ error : NetworkError) {
+    public static func thisError(_ error : NetworkError) {
         print("🤬 ERROR: \(error.localizedDescription)")
         print("🤖 RAW VALUE: \(error)")
         print("------------------------------------------")
     }
 
-    static func this(_ value : String, format: LogFormat = .full) {
+    public static func this(_ value : String, format: LogFormat = .full) {
         print("🔒 💾 \(value)")
     }
 }


### PR DESCRIPTION
Make core entity and logger symbols public so they can be used by downstream modules. Changes:
- Endpoint: made baseURL, path, httpMethod, contentType, body, parameters, query, headers and request public (Sources/Entity/Endpoint.swift).
- Tokens: made accessToken and refreshToken public (Sources/Entity/Tokens.swift).
- Logger: made LogType enum, Log struct and its static methods (this, thisCall, thisResponse, thisURL, thisError, this(value)) public (Sources/Logger/Log.swift).

These are visibility-only changes; no runtime behavior was modified.